### PR TITLE
Add custom port number configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ npm i mysqlconnector
 The library offer two main approach of a SQL operation: `query` and `transaction`  
 To connect to the database you have to use the `MySqlConnection` class
 ````typescript
-    const connection = new MySqlConnection('localhost', 'username', 'password');  
+    // const connection = new MySqlConnection('localhost', 'username', 'password');
+    const connection = new MySqlConnection({
+        hostname: "localhost",
+        username: "root",
+        password: "",
+        port: 3306,
+    });  
      
     connection.connectAsync().then(() => { 
         
@@ -30,7 +36,11 @@ To connect to the database you have to use the `MySqlConnection` class
 
 The use of `Promise` simplify the use of the `MySqlConnection` object
 ````typescript
-    const connection = new MySqlConnection('localhost', 'username', 'password');
+    const connection = new MySqlConnection({
+            hostname: "localhost",
+            username: "root",
+            password: "root"
+        });
      
     connection.connectAsync()
         .then(() => { })
@@ -42,7 +52,11 @@ The use of `Promise` simplify the use of the `MySqlConnection` object
 The same goes for the use of a query
 
 ````typescript
-    const connection = new MySqlConnection('localhost', 'username', 'password');
+    const connection = new MySqlConnection({
+        hostname: "localhost",
+        username: "root",
+        password: "root"
+    });
      
      ...
      
@@ -91,7 +105,12 @@ If any thing goes wrong the `rollback` will be executed. Using TypeScript with `
 a nicer way to make sure all your operation happen in the same transaction
 
 ````typescript
-        const mySql = new MySqlConnection("localhost", "root", "root", "test");
+        const mySql = new MySqlConnection({
+            hostname: "localhost",
+            username: "root",
+            password: "root",
+            database: "test"
+        });
         const dbContext = new DbContext(mySql);
         
         await dbContext.inTransactionAsync(async () => {
@@ -109,7 +128,12 @@ The `dbContext` can be pass to other function and the `inTransactionAsync` funct
 it still will be one transaction  
 
 ````typescript
-        const mySql = new MySqlConnection("localhost", "root", "root", "test");
+        const mySql = new MySqlConnection({
+            hostname: "localhost",
+            username: "root",
+            password: "root",
+            database: "test"
+        });
         const dbContext = new DbContext(mySql);
         
         

--- a/src/connection/connection.d.ts
+++ b/src/connection/connection.d.ts
@@ -1,13 +1,16 @@
 import mysql = require("mysql");
 import { Query } from "../queries/query";
 export declare class MySqlConnection {
-    private hostname?;
-    private username?;
-    private password?;
-    private db?;
+    private configuration;
     connected: boolean;
     conn: mysql.Connection | undefined;
-    constructor(hostname?: string | undefined, username?: string | undefined, password?: string | undefined, db?: string | undefined);
+    constructor(configuration: {
+        hostname?: string | undefined,
+        username?: string | undefined,
+        password?: string | undefined,
+        db?: string | undefined,
+        port?: number | undefined
+    });
     connectAsync(): Promise<void>;
     queryAsync(query: string): Promise<any>;
     closeAsync(): Promise<void>;

--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -6,17 +6,25 @@ export class MySqlConnection {
     public connected: boolean;
     public conn: mysql.Connection | undefined;
 
-    constructor(private hostname?: string, private username?: string, private password?: string, private db?: string) {
+    // constructor(private hostname?: string, private username?: string, private password?: string, private db?: string) {
+    constructor(private configuration: {
+        hostname?: string,
+        username?: string,
+        password?: string,
+        db?: string,
+        port?: number,
+    }) {
         this.connected = false;
     }
 
     public connectAsync() {
         return new Promise<void>((resolve, reject) => {
             this.conn = mysql.createConnection({
-                database: this.db,
-                host: this.hostname,
-                password: this.password,
-                user: this.username,
+                database: this.configuration.db,
+                host: this.configuration.hostname,
+                password: this.configuration.password,
+                user: this.configuration.username,
+                port: this.configuration.port,
             });
             this.conn.connect((error) => {
                 if (error) {

--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -24,7 +24,7 @@ export class MySqlConnection {
                 host: this.configuration.hostname,
                 password: this.configuration.password,
                 user: this.configuration.username,
-                port: this.configuration.port,
+                port: this.configuration.port ?? 3306,
             });
             this.conn.connect((error) => {
                 if (error) {

--- a/test/src/dbcontext.spec.ts
+++ b/test/src/dbcontext.spec.ts
@@ -16,7 +16,12 @@ let dbContext: DbContext;
 describe("DbContext", () => {
 
     before(async () => {
-        const initConnection = new MySqlConnection("127.0.0.1", "root", "");
+        // const initConnection = new MySqlConnection("127.0.0.1", "root", "");
+        const initConnection = new MySqlConnection({
+            hostname: "127.0.0.1",
+            username: "root",
+            password: ""
+        });
         const context = new DbContext(initConnection);
         await context.inTransactionAsync(async (db) => {
             await db.executeAsync(Drop.Database("test"));
@@ -32,7 +37,13 @@ describe("DbContext", () => {
     });
 
     beforeEach(() => {
-        mySql = new MySqlConnection("127.0.0.1", "root", "", "test");
+        // mySql = new MySqlConnection("127.0.0.1", "root", "", "test");
+        mySql = new MySqlConnection({
+            hostname: "127.0.0.1",
+            username: "root",
+            password: "",
+            db: "test"
+        });
         dbContext = new DbContext(mySql);
     });
 

--- a/test/src/mysqlconnection.spec.ts
+++ b/test/src/mysqlconnection.spec.ts
@@ -13,7 +13,12 @@ let mySql: MySqlConnection;
 describe("MySqlConnection", () => {
 
     before(async () => {
-        mySql = new MySqlConnection("127.0.0.1", "root", "");
+        // mySql = new MySqlConnection("127.0.0.1", "root", "");
+        mySql = new MySqlConnection({
+            hostname: "127.0.0.1",
+            username: "root",
+            password: ""
+        });
         await mySql.executeAsync(Drop.Database("test"));
         await mySql.executeAsync(Create.Database("test"));
         await mySql.executeAsync(Create.Table("test.user")
@@ -25,11 +30,24 @@ describe("MySqlConnection", () => {
     });
 
     beforeEach(() => {
-        mySql = new MySqlConnection("127.0.0.1", "root", "", "test");
+       // mySql = new MySqlConnection("127.0.0.1", "root", "", "test");
+       mySql = new MySqlConnection({
+            hostname: "127.0.0.1",
+            username: "root",
+            password: "",
+            db: "test"
+       });
     });
 
     it("Should throw an error if connection is not valid", () => {
-        const c: MySqlConnection = new MySqlConnection("127.0.0.1", "fake", "fake");
+        // const c: MySqlConnection = new MySqlConnection("127.0.0.1", "fake", "fake");
+        const c: MySqlConnection = new MySqlConnection(
+            {
+                hostname: "127.0.0.1",
+                username: "fake",
+                password: "fake"
+            }
+        );
         c.connectAsync().catch((exception) => {
             expect(exception).to.not.eq(null);
         });


### PR DESCRIPTION
There is no way to provide a specific port number in the original code. This pull request added it and changed the `MySqlConnection` constructor.

The new constructor looks like this:

```typescript
constructor(private configuration: {
  hostname?: string,
  username?: string,
  password?: string,
  db?: string,
  port?: number,
}) {
  this.connected = false;
}
```

**NOTE:** NOT TESTED, so I recommend that create a new branch if wish to accept this PR and merge to the master branch after testing.